### PR TITLE
Fixing hard coded paths to use the SENZING_DIR env variable.

### DIFF
--- a/docker-compose-kafka.yaml
+++ b/docker-compose-kafka.yaml
@@ -67,13 +67,13 @@ services:
     image: senzing/mysql-init
     container_name: senzing-mysql-init
     environment:
-      SENZING_SENTINEL_FILE: /opt/senzing/mysql-init.sentinel
+      SENZING_SENTINEL_FILE: ${SENZING_DIR:-/opt/senzing}/mysql-init.sentinel
     command:
       - --user=${MYSQL_USERNAME:-g2}
       - --password=${MYSQL_PASSWORD:-g2}
       - --host=mysql
       - --database=${MYSQL_DATABASE:-G2}
-      - --execute="source /opt/senzing/g2/data/g2core-schema-mysql-create.sql"
+      - --execute="source ${SENZING_DIR:-/opt/senzing}/g2/data/g2core-schema-mysql-create.sql"
     networks:
       - backend
     volumes:


### PR DESCRIPTION
with a default of '/opt/senzing' if SENZING_DIR is not defined.

## Which issue does this address

ISSUE-5

## Why was change needed

To get senzing-mysql-init to run successfully when senzing is installed in a non-default location.

## What does change improve

senzing-mysql-init will run successfully when senzing is at a non-default location.
