### PR TITLE
Using SENZING_DIR instead of assuming senzing install location.

### DIFF
--- a/docker-compose-init.yaml
+++ b/docker-compose-init.yaml
@@ -20,13 +20,13 @@ services:
     image: senzing/mysql-init
     container_name: senzing-mysql-init
     environment:
-      SENZING_SENTINEL_FILE: /opt/senzing/mysql-init.sentinel
+      SENZING_SENTINEL_FILE: ${SENZING_DIR:-/opt/senzing}/mysql-init.sentinel
     command:
       - --user=${MYSQL_USERNAME:-g2}
       - --password=${MYSQL_PASSWORD:-g2}
       - --host=mysql
       - --database=${MYSQL_DATABASE:-G2}
-      - --execute="source /opt/senzing/g2/data/g2core-schema-mysql-create.sql"
+      - --execute="source ${SENZING_DIR:-/opt/senzing}/g2/data/g2core-schema-mysql-create.sql"
     networks:
       - backend
     volumes:


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

ISSUE-11

## Why was change needed

To use non standard SENZING_DIR locations

## What does change improve

docker-compose-init.yaml now works with non default install locations.
